### PR TITLE
Remove comments and switch build on

### DIFF
--- a/recipes/stingray/meta.yaml
+++ b/recipes/stingray/meta.yaml
@@ -25,7 +25,7 @@ build:
   # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
   # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
   # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
-  # noarch: python
+  noarch: python
   number: 0
   # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
   # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
@@ -66,10 +66,10 @@ about:
 
   # The remaining entries in this section are optional, but recommended
   description: |
-    This Astropy-affiliated software package merges existing efforts for a timing package in Python 
-    and provides the basis for developing spectral-timing analysis tools. It is 
-    structured with the best guidelines for modern open-source programming, 
-    following the example of Astropy. 
+    This Astropy-affiliated software package merges existing efforts for a timing package in Python
+    and provides the basis for developing spectral-timing analysis tools. It is
+    structured with the best guidelines for modern open-source programming,
+    following the example of Astropy.
   doc_url: http://stingray.readthedocs.io/
   dev_url: https://github.com/StingraySoftware/stingray
 

--- a/recipes/stingray/meta.yaml
+++ b/recipes/stingray/meta.yaml
@@ -1,13 +1,6 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
 {% set name = "stingray" %}
 {% set version = "0.1.dev1333 %}
 {% set sha256 = "7b5588bfc38f2208baa6a147445067ba49fa485a98664c1aa39ae52176626c50" %}
-# sha256 is the prefered checksum -- you can get it for a file with:
-#  `openssl sha256 <file name>`.
-# You may need the openssl package, available on conda-forge
-#  `conda install openssl -c conda-forge``
 
 package:
   name: {{ name|lower }}
@@ -16,33 +9,21 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # If getting the source from GitHub remove the line above
-  # uncomment the line below and modify as needed
-  # url: https://github.com/simplejson/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
-  noarch: python
   number: 0
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
     - pip
-    # if your project compiles code (such as a C extension) then add `toolchain` as a build requirement.
   run:
     - python
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - python
     - matplotlib
@@ -52,19 +33,11 @@ test:
 
 about:
   home: http://github.com/StingraySoftware/stingray
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
   license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
   license_family: MIT
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
   license_file: LICENSE.txt
   summary: 'The Next Generation Spectral Timing Software'
 
-  # The remaining entries in this section are optional, but recommended
   description: |
     This Astropy-affiliated software package merges existing efforts for a timing package in Python
     and provides the basis for developing spectral-timing analysis tools. It is
@@ -75,8 +48,6 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - matteobachetti
     - dhuppenkothen
     - evandromr


### PR DESCRIPTION
Remove all comments and most importantly remove the comment on `noarch: python` that allows the python build